### PR TITLE
Jolteon 166 end renting logic on backend

### DIFF
--- a/backend/src/main/java/tqs/project/jolteon/controllers/BikeRentingController.java
+++ b/backend/src/main/java/tqs/project/jolteon/controllers/BikeRentingController.java
@@ -11,9 +11,7 @@ import java.util.Set;
 import java.time.LocalDateTime;
 import java.util.stream.Collectors;
 import tqs.project.jolteon.entities.BikeRenting;
-import tqs.project.jolteon.entities.DTOs.CulturalLandmarkDTO;
-import tqs.project.jolteon.entities.DTOs.UserDTO;
-import tqs.project.jolteon.entities.DTOs.BikeDTO;
+
 
 
 @RestController
@@ -48,29 +46,27 @@ public class BikeRentingController {
         Long startSpotId = bikeRentingDTO.getStartSpot() != null ? bikeRentingDTO.getStartSpot().getId() : null;
         Long endSpotId = bikeRentingDTO.getEndSpot() != null ? bikeRentingDTO.getEndSpot().getId() : null;
         Set<Long> landmarkIds = bikeRentingDTO.getCulturalLandmarks() != null
-            ? bikeRentingDTO.getCulturalLandmarks().stream()
-                .map(landmark -> landmark.getId())
-                .collect(Collectors.toSet())
-            : null;
+                ? bikeRentingDTO.getCulturalLandmarks().stream()
+                        .map(landmark -> landmark.getId())
+                        .collect(Collectors.toSet())
+                : null;
         LocalDateTime time = bikeRentingDTO.getTime();
         LocalDateTime endTime = bikeRentingDTO.getEndTime();
         BikeRenting bikeRenting = bikeRentingService.createBikeRenting(
-            bikeId, userId, startSpotId, endSpotId, landmarkIds, time, endTime
-        );
+                bikeId, userId, startSpotId, endSpotId, landmarkIds, time, endTime);
 
         BikeRentingDTO createdDto = BikeRentingMapper.toDTO(bikeRenting);
         return ResponseEntity.ok(createdDto);
     }
 
-
-@PutMapping("{rentingId}/end")
-public ResponseEntity<BikeRentingDTO> endRenting(
-        @PathVariable Long rentingId,
-        @RequestParam LocalDateTime endTime,
-        @RequestParam Long endSpotId) {
-    BikeRenting updatedRenting = bikeRentingService.endBikeRenting(rentingId, endTime, endSpotId);
-    BikeRentingDTO updatedDto = BikeRentingMapper.toDTO(updatedRenting);
-    return ResponseEntity.ok(updatedDto);
-}
+    @PutMapping("{rentingId}/end")
+    public ResponseEntity<BikeRentingDTO> endRenting(
+            @PathVariable Long rentingId,
+            @RequestParam LocalDateTime endTime,
+            @RequestParam Long endSpotId) {
+        BikeRenting updatedRenting = bikeRentingService.endBikeRenting(rentingId, endTime, endSpotId);
+        BikeRentingDTO updatedDto = BikeRentingMapper.toDTO(updatedRenting);
+        return ResponseEntity.ok(updatedDto);
+    }
 
 }

--- a/backend/src/main/java/tqs/project/jolteon/controllers/BikeRentingController.java
+++ b/backend/src/main/java/tqs/project/jolteon/controllers/BikeRentingController.java
@@ -61,4 +61,16 @@ public class BikeRentingController {
         BikeRentingDTO createdDto = BikeRentingMapper.toDTO(bikeRenting);
         return ResponseEntity.ok(createdDto);
     }
+
+
+@PutMapping("{rentingId}/end")
+public ResponseEntity<BikeRentingDTO> endRenting(
+        @PathVariable Long rentingId,
+        @RequestParam LocalDateTime endTime,
+        @RequestParam Long endSpotId) {
+    BikeRenting updatedRenting = bikeRentingService.endBikeRenting(rentingId, endTime, endSpotId);
+    BikeRentingDTO updatedDto = BikeRentingMapper.toDTO(updatedRenting);
+    return ResponseEntity.ok(updatedDto);
+}
+
 }

--- a/backend/src/main/java/tqs/project/jolteon/services/BikeRentingService.java
+++ b/backend/src/main/java/tqs/project/jolteon/services/BikeRentingService.java
@@ -101,4 +101,18 @@ public class BikeRentingService {
                 .orElseThrow(() -> new IllegalArgumentException("Bike renting not found"));
     }
 
+
+    @Transactional
+    public BikeRenting endBikeRenting(Long id, LocalDateTime endTime, Long endSpotId) {
+        BikeRenting renting = bikeRentingRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Bike renting not found"));
+        ChargingSpot endSpot = chargingSpotRepository.findById(endSpotId)
+                .orElseThrow(() -> new IllegalArgumentException("End spot not found"));
+        renting.setEndTime(endTime);
+        renting.setEndSpot(endSpot);
+        renting.getBike().setIsAvailable(true);
+        renting.getBike().setChargingSpot(endSpot);
+        return bikeRentingRepository.save(renting);
+    }
+
 }

--- a/backend/src/main/java/tqs/project/jolteon/services/BikeRentingService.java
+++ b/backend/src/main/java/tqs/project/jolteon/services/BikeRentingService.java
@@ -2,6 +2,8 @@ package tqs.project.jolteon.services;
 
 
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tqs.project.jolteon.entities.*;
@@ -16,10 +18,19 @@ import java.util.List;
 public class BikeRentingService {
 
     private final BikeRentingRepository bikeRentingRepository;
-    private final BikeRepository bikeRepository;
-    private final NormalUserRepository userRepository;
-    private final ChargingSpotRepository chargingSpotRepository;
-    private final CulturalLandmarkRepository culturalLandmarkRepository;
+
+    @Autowired
+    private final BikeService bikeService;
+
+    @Autowired
+    private final NormalUserService userService;
+
+    @Autowired
+    private final ChargingSpotService chargingSpotService;
+
+    @Autowired
+    private final CulturalLandmarkService culturalLandmarkService;
+
 
     @Transactional
     public BikeRenting createBikeRenting(Long bikeId,
@@ -30,20 +41,19 @@ public class BikeRentingService {
                                          LocalDateTime time,
                                          LocalDateTime endTime) {
 
-        Bike bike = bikeRepository.findById(bikeId)
+        // Bike bike = bikeRepository.findById(bikeId)
+        //         .orElseThrow(() -> new IllegalArgumentException("Bike not found"));
+        Bike bike = bikeService.getBikeById(bikeId)
                 .orElseThrow(() -> new IllegalArgumentException("Bike not found"));
 
-        NormalUser user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+        NormalUser user = userService.getNormalUserById(userId);
 
-        ChargingSpot startSpot = chargingSpotRepository.findById(startSpotId)
-                .orElseThrow(() -> new IllegalArgumentException("Start spot not found"));
+        ChargingSpot startSpot = chargingSpotService.getChargingSpotById(startSpotId);
 
         ChargingSpot endSpot = null;
 
         if (endSpotId != null) {
-             endSpot = chargingSpotRepository.findById(endSpotId)
-                .orElseThrow(() -> new IllegalArgumentException("End spot not found"));
+             endSpot = chargingSpotService.getChargingSpotById(endSpotId);
         } 
 
         // make bike unavailable
@@ -58,7 +68,7 @@ public class BikeRentingService {
         }
 
 
-        Set<CulturalLandmark> landmarks = culturalLandmarkRepository.findAllByIdIn(landmarkIds);
+        Set<CulturalLandmark> landmarks = culturalLandmarkService.getCulturalLandmarksByIds(landmarkIds);
 
         BikeRenting renting = new BikeRenting();
         renting.setBike(bike);
@@ -117,8 +127,7 @@ public class BikeRentingService {
     public BikeRenting endBikeRenting(Long id, LocalDateTime endTime, Long endSpotId) {
         BikeRenting renting = bikeRentingRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Bike renting not found"));
-        ChargingSpot endSpot = chargingSpotRepository.findById(endSpotId)
-                .orElseThrow(() -> new IllegalArgumentException("End spot not found"));
+        ChargingSpot endSpot = chargingSpotService.getChargingSpotById(endSpotId);
         renting.setEndTime(endTime);
         renting.setEndSpot(endSpot);
         renting.getBike().setIsAvailable(true);

--- a/backend/src/main/java/tqs/project/jolteon/services/BikeRentingService.java
+++ b/backend/src/main/java/tqs/project/jolteon/services/BikeRentingService.java
@@ -46,6 +46,17 @@ public class BikeRentingService {
                 .orElseThrow(() -> new IllegalArgumentException("End spot not found"));
         } 
 
+        // make bike unavailable
+        if (!bike.getIsAvailable()) {
+            throw new IllegalArgumentException("Bike is not available for renting");
+        }
+        bike.setIsAvailable(false);
+
+        // Remove chargingspot from bike
+        if (bike.getChargingSpot() != null) {
+            bike.setChargingSpot(null);
+        }
+
 
         Set<CulturalLandmark> landmarks = culturalLandmarkRepository.findAllByIdIn(landmarkIds);
 

--- a/backend/src/main/java/tqs/project/jolteon/services/BikeRentingService.java
+++ b/backend/src/main/java/tqs/project/jolteon/services/BikeRentingService.java
@@ -18,17 +18,9 @@ import java.util.List;
 public class BikeRentingService {
 
     private final BikeRentingRepository bikeRentingRepository;
-
-    @Autowired
     private final BikeService bikeService;
-
-    @Autowired
     private final NormalUserService userService;
-
-    @Autowired
     private final ChargingSpotService chargingSpotService;
-
-    @Autowired
     private final CulturalLandmarkService culturalLandmarkService;
 
 
@@ -41,8 +33,6 @@ public class BikeRentingService {
                                          LocalDateTime time,
                                          LocalDateTime endTime) {
 
-        // Bike bike = bikeRepository.findById(bikeId)
-        //         .orElseThrow(() -> new IllegalArgumentException("Bike not found"));
         Bike bike = bikeService.getBikeById(bikeId)
                 .orElseThrow(() -> new IllegalArgumentException("Bike not found"));
 

--- a/backend/src/main/java/tqs/project/jolteon/services/CulturalLandmarkService.java
+++ b/backend/src/main/java/tqs/project/jolteon/services/CulturalLandmarkService.java
@@ -3,6 +3,7 @@ package tqs.project.jolteon.services;
 import org.springframework.stereotype.Service;
 import tqs.project.jolteon.entities.CulturalLandmark;
 import tqs.project.jolteon.repositories.CulturalLandmarkRepository;
+import java.util.Set;
 
 import java.util.List;
 
@@ -44,5 +45,9 @@ public class CulturalLandmarkService {
             throw new IllegalArgumentException("Cultural landmark not found with id: " + culturalLandmark.getId());
         }
         return culturalLandmarkRepository.save(culturalLandmark);
+    }
+
+    public Set<CulturalLandmark> getCulturalLandmarksByIds(Set<Long> ids) {
+        return culturalLandmarkRepository.findAllByIdIn(ids);
     }
 }

--- a/backend/src/test/java/tqs/project/jolteon/controllers/BikeRentingControllerTest.java
+++ b/backend/src/test/java/tqs/project/jolteon/controllers/BikeRentingControllerTest.java
@@ -153,4 +153,36 @@ class BikeRentingControllerTest {
                                 .andExpect(jsonPath("$.time").value("2025-06-03T19:37:48.326"));
         }
 
+
+
+
+@Test
+void endRenting_updatesAndReturnsBikeRentingDTO() throws Exception {
+    BikeRenting renting = createBikeRentingEntity(1L);
+    renting.setEndTime(LocalDateTime.of(2023, 1, 1, 12, 0));
+
+    ChargingSpot endSpot = new ChargingSpot();
+    endSpot.setId(2L);
+    renting.setEndSpot(endSpot);
+
+    Mockito.when(bikeRentingService.endBikeRenting(
+                    Mockito.eq(1L),
+                    Mockito.any(LocalDateTime.class),
+                    Mockito.eq(2L)))
+            .thenReturn(renting);
+
+    mockMvc.perform(
+            org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+                    .put("/api/rentings/1/end")
+                    .param("endTime", "2023-01-01T12:00:00")
+                    .param("endSpotId", "2")
+                    .contentType(MediaType.APPLICATION_JSON))  // contentType here is optional but fine
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.id").value(renting.getId()))
+            .andExpect(jsonPath("$.endTime").value("2023-01-01T12:00:00"))
+            .andExpect(jsonPath("$.endSpot.id").value(2));
+}
+
+
 }

--- a/backend/src/test/java/tqs/project/jolteon/services/BikeRentingServiceTest.java
+++ b/backend/src/test/java/tqs/project/jolteon/services/BikeRentingServiceTest.java
@@ -183,5 +183,40 @@ public class BikeRentingServiceTest {
         assertEquals("Bike not found", e.getMessage());
     }
 
-    // Add similar negative tests for user not found, start spot not found, etc.
+    // @Transactional
+    // public BikeRenting endBikeRenting(Long id, LocalDateTime endTime, Long endSpotId) {
+    //     BikeRenting renting = bikeRentingRepository.findById(id)
+    //             .orElseThrow(() -> new IllegalArgumentException("Bike renting not found"));
+    //     ChargingSpot endSpot = chargingSpotService.getChargingSpotById(endSpotId);
+    //     renting.setEndTime(endTime);
+    //     renting.setEndSpot(endSpot);
+    //     renting.getBike().setIsAvailable(true);
+    //     renting.getBike().setChargingSpot(endSpot);
+    //     return bikeRentingRepository.save(renting);
+    // }
+
+
+
+    @Test
+    public void testEndBikeRenting_Success() {
+        BikeRenting renting = new BikeRenting();
+        renting.setId(1L);
+        renting.setBike(bike);
+        renting.setEndTime(null);
+        renting.setEndSpot(null);
+
+        when(bikeRentingRepository.findById(1L)).thenReturn(Optional.of(renting));
+        when(chargingSpotService.getChargingSpotById(2L)).thenReturn(endSpot);
+        when(bikeRentingRepository.save(any(BikeRenting.class))).thenAnswer(i -> i.getArgument(0));
+
+        BikeRenting result = bikeRentingService.endBikeRenting(1L, endTime, 2L);
+
+        assertThat(result.getEndTime()).isEqualTo(endTime);
+        assertThat(result.getEndSpot()).isEqualTo(endSpot);
+        assertThat(result.getBike().getIsAvailable()).isTrue();
+    }
+
+
+
+
 }

--- a/backend/src/test/java/tqs/project/jolteon/services/BikeRentingServiceTest.java
+++ b/backend/src/test/java/tqs/project/jolteon/services/BikeRentingServiceTest.java
@@ -17,11 +17,16 @@ import static org.mockito.Mockito.*;
 
 public class BikeRentingServiceTest {
 
-    @Mock private BikeRentingRepository bikeRentingRepository;
-    @Mock private BikeService bikeService;
-    @Mock private ChargingSpotService chargingSpotService;
-    @Mock private NormalUserService userService;
-    @Mock private CulturalLandmarkService culturalLandmarkService;
+    @Mock
+    private BikeRentingRepository bikeRentingRepository;
+    @Mock
+    private BikeService bikeService;
+    @Mock
+    private ChargingSpotService chargingSpotService;
+    @Mock
+    private NormalUserService userService;
+    @Mock
+    private CulturalLandmarkService culturalLandmarkService;
 
     @InjectMocks
     private BikeRentingService bikeRentingService;
@@ -59,10 +64,11 @@ public class BikeRentingServiceTest {
         endTime = LocalDateTime.now();
     }
 
-
     @Test
     public void testCreateBikeRenting_Success() {
         bike.setIsAvailable(true);
+        bike.setChargingSpot(startSpot);
+
         when(bikeService.getBikeById(1L)).thenReturn(Optional.of(bike));
         when(userService.getNormalUserById(1L)).thenReturn(user);
         when(chargingSpotService.getChargingSpotById(1L)).thenReturn(startSpot);
@@ -71,8 +77,7 @@ public class BikeRentingServiceTest {
         when(bikeRentingRepository.save(any(BikeRenting.class))).thenAnswer(i -> i.getArgument(0));
 
         BikeRenting result = bikeRentingService.createBikeRenting(
-                1L, 1L, 1L, 2L, Set.of(1L), time, endTime
-        );
+                1L, 1L, 1L, 2L, Set.of(1L), time, endTime);
 
         assertThat(result.getBike()).isEqualTo(bike);
         assertThat(result.getUser()).isEqualTo(user);
@@ -81,6 +86,9 @@ public class BikeRentingServiceTest {
         assertThat(result.getCulturalLandmarks()).contains(landmark);
         assertThat(result.getTime()).isEqualTo(time);
         assertThat(result.getEndTime()).isEqualTo(endTime);
+
+        assertThat(bike.getIsAvailable()).isFalse();
+        assertThat(bike.getChargingSpot()).isNull();
     }
 
     @Test
@@ -91,14 +99,12 @@ public class BikeRentingServiceTest {
         when(chargingSpotService.getChargingSpotById(1L)).thenReturn(startSpot);
         when(chargingSpotService.getChargingSpotById(2L)).thenReturn(endSpot);
         when(culturalLandmarkService.getCulturalLandmarksByIds(Set.of(1L))).thenReturn(landmarks);
-        Exception e = assertThrows(IllegalArgumentException.class, () ->
-                bikeRentingService.createBikeRenting(1L, 1L, 1L, 2L, Set.of(1L), time, endTime)
-        );
+        Exception e = assertThrows(IllegalArgumentException.class,
+                () -> bikeRentingService.createBikeRenting(1L, 1L, 1L, 2L, Set.of(1L), time, endTime));
         assertEquals("Bike is not available for renting", e.getMessage());
 
         verify(bikeRentingRepository, never()).save(any(BikeRenting.class));
     }
-
 
     @Test
     public void testGetById() {
@@ -177,25 +183,10 @@ public class BikeRentingServiceTest {
     @Test
     public void testCreateBikeRenting_BikeNotFound() {
         when(bikeService.getBikeById(99L)).thenReturn(Optional.empty());
-        Exception e = assertThrows(IllegalArgumentException.class, () ->
-                bikeRentingService.createBikeRenting(99L, 1L, 1L, 2L, Set.of(1L), time, endTime)
-        );
+        Exception e = assertThrows(IllegalArgumentException.class,
+                () -> bikeRentingService.createBikeRenting(99L, 1L, 1L, 2L, Set.of(1L), time, endTime));
         assertEquals("Bike not found", e.getMessage());
     }
-
-    // @Transactional
-    // public BikeRenting endBikeRenting(Long id, LocalDateTime endTime, Long endSpotId) {
-    //     BikeRenting renting = bikeRentingRepository.findById(id)
-    //             .orElseThrow(() -> new IllegalArgumentException("Bike renting not found"));
-    //     ChargingSpot endSpot = chargingSpotService.getChargingSpotById(endSpotId);
-    //     renting.setEndTime(endTime);
-    //     renting.setEndSpot(endSpot);
-    //     renting.getBike().setIsAvailable(true);
-    //     renting.getBike().setChargingSpot(endSpot);
-    //     return bikeRentingRepository.save(renting);
-    // }
-
-
 
     @Test
     public void testEndBikeRenting_Success() {
@@ -215,8 +206,5 @@ public class BikeRentingServiceTest {
         assertThat(result.getEndSpot()).isEqualTo(endSpot);
         assertThat(result.getBike().getIsAvailable()).isTrue();
     }
-
-
-
 
 }

--- a/backend/src/test/java/tqs/project/jolteon/services/BikeRentingServiceTest.java
+++ b/backend/src/test/java/tqs/project/jolteon/services/BikeRentingServiceTest.java
@@ -83,6 +83,23 @@ public class BikeRentingServiceTest {
     }
 
     @Test
+    public void testCreateBikeRenting_BikeNotAvailable() {
+        bike.setIsAvailable(false);
+        when(bikeRepository.findById(1L)).thenReturn(Optional.of(bike));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(chargingSpotRepository.findById(1L)).thenReturn(Optional.of(startSpot));
+        when(chargingSpotRepository.findById(2L)).thenReturn(Optional.of(endSpot));
+        when(culturalLandmarkRepository.findAllByIdIn(Set.of(1L))).thenReturn(landmarks);
+        Exception e = assertThrows(IllegalArgumentException.class, () ->
+                bikeRentingService.createBikeRenting(1L, 1L, 1L, 2L, Set.of(1L), time, endTime)
+        );
+        assertEquals("Bike is not available for renting", e.getMessage());
+
+        verify(bikeRentingRepository, never()).save(any(BikeRenting.class));
+    }
+
+
+    @Test
     public void testGetById() {
         BikeRenting renting = new BikeRenting();
         renting.setId(5L);

--- a/backend/src/test/java/tqs/project/jolteon/services/BikeRentingServiceTest.java
+++ b/backend/src/test/java/tqs/project/jolteon/services/BikeRentingServiceTest.java
@@ -61,6 +61,7 @@ public class BikeRentingServiceTest {
 
     @Test
     public void testCreateBikeRenting_Success() {
+        bike.setIsAvailable(true);
         when(bikeRepository.findById(1L)).thenReturn(Optional.of(bike));
         when(userRepository.findById(1L)).thenReturn(Optional.of(user));
         when(chargingSpotRepository.findById(1L)).thenReturn(Optional.of(startSpot));

--- a/backend/src/test/java/tqs/project/jolteon/services/BikeRentingServiceTest.java
+++ b/backend/src/test/java/tqs/project/jolteon/services/BikeRentingServiceTest.java
@@ -18,10 +18,10 @@ import static org.mockito.Mockito.*;
 public class BikeRentingServiceTest {
 
     @Mock private BikeRentingRepository bikeRentingRepository;
-    @Mock private BikeRepository bikeRepository;
-    @Mock private NormalUserRepository userRepository;
-    @Mock private ChargingSpotRepository chargingSpotRepository;
-    @Mock private CulturalLandmarkRepository culturalLandmarkRepository;
+    @Mock private BikeService bikeService;
+    @Mock private ChargingSpotService chargingSpotService;
+    @Mock private NormalUserService userService;
+    @Mock private CulturalLandmarkService culturalLandmarkService;
 
     @InjectMocks
     private BikeRentingService bikeRentingService;
@@ -59,14 +59,15 @@ public class BikeRentingServiceTest {
         endTime = LocalDateTime.now();
     }
 
+
     @Test
     public void testCreateBikeRenting_Success() {
         bike.setIsAvailable(true);
-        when(bikeRepository.findById(1L)).thenReturn(Optional.of(bike));
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-        when(chargingSpotRepository.findById(1L)).thenReturn(Optional.of(startSpot));
-        when(chargingSpotRepository.findById(2L)).thenReturn(Optional.of(endSpot));
-        when(culturalLandmarkRepository.findAllByIdIn(Set.of(1L))).thenReturn(landmarks);
+        when(bikeService.getBikeById(1L)).thenReturn(Optional.of(bike));
+        when(userService.getNormalUserById(1L)).thenReturn(user);
+        when(chargingSpotService.getChargingSpotById(1L)).thenReturn(startSpot);
+        when(chargingSpotService.getChargingSpotById(2L)).thenReturn(endSpot);
+        when(culturalLandmarkService.getCulturalLandmarksByIds(Set.of(1L))).thenReturn(landmarks);
         when(bikeRentingRepository.save(any(BikeRenting.class))).thenAnswer(i -> i.getArgument(0));
 
         BikeRenting result = bikeRentingService.createBikeRenting(
@@ -85,11 +86,11 @@ public class BikeRentingServiceTest {
     @Test
     public void testCreateBikeRenting_BikeNotAvailable() {
         bike.setIsAvailable(false);
-        when(bikeRepository.findById(1L)).thenReturn(Optional.of(bike));
-        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
-        when(chargingSpotRepository.findById(1L)).thenReturn(Optional.of(startSpot));
-        when(chargingSpotRepository.findById(2L)).thenReturn(Optional.of(endSpot));
-        when(culturalLandmarkRepository.findAllByIdIn(Set.of(1L))).thenReturn(landmarks);
+        when(bikeService.getBikeById(1L)).thenReturn(Optional.of(bike));
+        when(userService.getNormalUserById(1L)).thenReturn(user);
+        when(chargingSpotService.getChargingSpotById(1L)).thenReturn(startSpot);
+        when(chargingSpotService.getChargingSpotById(2L)).thenReturn(endSpot);
+        when(culturalLandmarkService.getCulturalLandmarksByIds(Set.of(1L))).thenReturn(landmarks);
         Exception e = assertThrows(IllegalArgumentException.class, () ->
                 bikeRentingService.createBikeRenting(1L, 1L, 1L, 2L, Set.of(1L), time, endTime)
         );
@@ -175,7 +176,7 @@ public class BikeRentingServiceTest {
 
     @Test
     public void testCreateBikeRenting_BikeNotFound() {
-        when(bikeRepository.findById(99L)).thenReturn(Optional.empty());
+        when(bikeService.getBikeById(99L)).thenReturn(Optional.empty());
         Exception e = assertThrows(IllegalArgumentException.class, () ->
                 bikeRentingService.createBikeRenting(99L, 1L, 1L, 2L, Set.of(1L), time, endTime)
         );

--- a/backend/src/test/java/tqs/project/jolteon/services/CulturalLandmarkServiceTest.java
+++ b/backend/src/test/java/tqs/project/jolteon/services/CulturalLandmarkServiceTest.java
@@ -1,5 +1,6 @@
 package tqs.project.jolteon.services;
 
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -102,4 +103,16 @@ class CulturalLandmarkServiceTest {
         verify(culturalLandmarkRepository, times(1)).existsById(999L);
         verify(culturalLandmarkRepository, never()).save(landmark);
     }
+
+
+
+    @Test
+    void testGetCulturalLandmarksByIds() {
+        List<CulturalLandmark> landmarks = Arrays.asList(new CulturalLandmark(), new CulturalLandmark());
+        when(culturalLandmarkRepository.findAllByIdIn(Set.of(1L, 2L))).thenReturn(Set.copyOf(landmarks));
+        Set<CulturalLandmark> result = culturalLandmarkService.getCulturalLandmarksByIds(Set.of(1L, 2L));
+        assertEquals(2, result.size());
+        verify(culturalLandmarkRepository, times(1)).findAllByIdIn(Set.of(1L, 2L));
+    }
+
 }


### PR DESCRIPTION
## Description

Adding the logic for ending the rentings. 

## Type of Change

- [ ] Bug fix
- [X] New feature
- [X] Refactor


## How Has This Been Tested?


- [X] Unit tests
- [X] Integration tests
- [X] Manual tests

Copilot disse:
This pull request refactors the bike renting functionality in the backend by replacing direct repository usage with service-layer calls, adding new methods to manage bike availability and rental completion, and updating corresponding tests. The changes improve modularity, encapsulation, and maintainability of the codebase.

### Refactoring for Service-Layer Usage:
* Replaced direct repository access (`BikeRepository`, `NormalUserRepository`, `ChargingSpotRepository`, `CulturalLandmarkRepository`) with corresponding service-layer calls (`BikeService`, `NormalUserService`, `ChargingSpotService`, `CulturalLandmarkService`) in `BikeRentingService`. This includes methods like `getBikeById`, `getNormalUserById`, and `getChargingSpotById`. [[1]](diffhunk://#diff-73000029f14297dea6a3c57f23e6f2a959de55f307a5b70d65ef1b03824121dcL19-R33) [[2]](diffhunk://#diff-73000029f14297dea6a3c57f23e6f2a959de55f307a5b70d65ef1b03824121dcL33-R71)

### New Feature for Rental Completion:
* Added a new endpoint `PUT /{rentingId}/end` in `BikeRentingController` to mark a bike rental as completed. It updates the rental's end time, end spot, and makes the bike available again.
* Implemented the `endBikeRenting` method in `BikeRentingService` to handle rental completion logic, including updating bike availability and assigning the end spot.

### Enhancements to Bike Availability:
* Added checks in `BikeRentingService` to ensure bikes are available before renting. Bikes are marked as unavailable when rented and their association with charging spots is removed.

### Updates to Cultural Landmark Service:
* Added a new method `getCulturalLandmarksByIds` in `CulturalLandmarkService` to fetch landmarks by their IDs, replacing repository calls in `BikeRentingService`.

### Test Updates:
* Refactored tests in `BikeRentingServiceTest` to mock service-layer calls instead of repositories, ensuring alignment with the updated implementation. [[1]](diffhunk://#diff-e7f05e27bd712c2e0ebd3c6e143da1e0a8026d6209d96e1b008d369d64ef7912L21-R24) [[2]](diffhunk://#diff-e7f05e27bd712c2e0ebd3c6e143da1e0a8026d6209d96e1b008d369d64ef7912R62-R70)
* Added a new test case to verify that bike renting fails when the bike is unavailable.


