### PR TITLE
Grafana crendentials fixed

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -43,6 +43,9 @@ services:
     image: grafana/grafana
     ports:
       - ${GRAFANA_PORTS}
+    environment:
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_USER}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
     volumes:
       - grafana-storage:/var/lib/grafana
     depends_on:


### PR DESCRIPTION
## Description

Fixed login issue. Turns out the credentials change was not saved before, now it is. Username and pwd are in .env_example

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Entered grafana and tested with the correct credentials, stored in .env_example

